### PR TITLE
Add ability to display and update a Date object

### DIFF
--- a/Sources/UserDefaultsUI/Editors/AddUserDefaultEditor.swift
+++ b/Sources/UserDefaultsUI/Editors/AddUserDefaultEditor.swift
@@ -62,6 +62,13 @@ struct AddUserDefaultEditor: View {
                         dismiss()
                     }
                     
+                case .date(let value):
+                    DateValueEditor(date: value) { date in
+                        let key = key.trimmingCharacters(in: .whitespacesAndNewlines)
+                        model.actions.setValue(date, forKey: key)
+                        dismiss()
+                    }
+                    
                 case .other(_):
                     Text("Type is not editable")
                 }

--- a/Sources/UserDefaultsUI/Editors/DateValueEditor.swift
+++ b/Sources/UserDefaultsUI/Editors/DateValueEditor.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct DateValueEditor: View {
+
+    @State private var date: Date
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    private var apply: (Date) -> Void
+
+    init(date: Date, apply: @escaping (Date) -> Void) {
+        self.date = date
+        self.apply = apply
+    }
+    
+    var body: some View {
+        VStack {
+            Text(date.ISO8601Format(.iso8601))
+                .frame(maxWidth: .infinity)
+                .border(Color(UIColor.label), width: 0.5)
+            DatePicker(selection: $date) {
+                Text("New date")
+            }
+            .datePickerStyle(.graphical)
+            .padding(.vertical, 2)
+            .padding(.horizontal, 4)
+            .cornerRadius(8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(white: 0, opacity: 0.1), lineWidth: 1)
+            )
+            .padding()
+
+            Button {
+                apply(date)
+                dismiss()
+            } label: {
+                Text("Apply")
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.bottom)
+            Spacer()
+        }
+    }
+}
+
+#if swift(>=5.9)
+
+#Preview {
+    DateValueEditor(date: Date.now, apply: { date in print(date) })
+}
+
+#endif

--- a/Sources/UserDefaultsUI/Editors/UserDefaultEntryEditor.swift
+++ b/Sources/UserDefaultsUI/Editors/UserDefaultEntryEditor.swift
@@ -47,6 +47,11 @@ struct UserDefaultEntryEditor: View {
                 StringValueEditor(text: value) { text in
                     model.actions.setValue(text, forKey: entry.key)
                 }
+
+            case .date(let value):
+                DateValueEditor(date: value) { date in
+                    model.actions.setValue(date, forKey: entry.key)
+                }
             
             case .other(_):
                 Text("\(entry.type) is not editable")

--- a/Sources/UserDefaultsUI/Model/Actions/MockUserDefaultsActions.swift
+++ b/Sources/UserDefaultsUI/Model/Actions/MockUserDefaultsActions.swift
@@ -47,6 +47,10 @@ public class MockUserDefaultsActions: UserDefaultsActions {
     public func valueForKey(_ key: String) -> String? {
         defaults[key] as? String
     }
+
+    public func valueForKey(_ key: String) -> Date? {
+        defaults[key] as? Date
+    }
     
     public func valueForKey(_ key: String) -> Any? {
         defaults[key]

--- a/Sources/UserDefaultsUI/Model/Actions/StandardUserDefaultsActions.swift
+++ b/Sources/UserDefaultsUI/Model/Actions/StandardUserDefaultsActions.swift
@@ -44,6 +44,10 @@ public struct StandardUserDefaultsActions: UserDefaultsActions {
         userDefaults.string(forKey: key)
     }
     
+    public func valueForKey(_ key: String) -> Date? {
+        userDefaults.object(forKey: key) as? Date
+    }
+
     public func valueForKey(_ key: String) -> Any? {
         userDefaults.object(forKey: key)
     }

--- a/Sources/UserDefaultsUI/Model/UserDefaultValue.swift
+++ b/Sources/UserDefaultsUI/Model/UserDefaultValue.swift
@@ -7,6 +7,7 @@ enum UserDefaultValue: Identifiable {
     case float(Float)
     case double(Double)
     case string(String)
+    case date(Date)
     case other(Any)
     
     var id: String {
@@ -21,6 +22,8 @@ enum UserDefaultValue: Identifiable {
             return "double(\(value))"
         case .string(let value):
             return "string(\(value))"
+        case .date(let value):
+            return "date(\(value))"
         case .other(_):
             return "other"
         }
@@ -34,6 +37,8 @@ enum UserDefaultValue: Identifiable {
             self = value.asUserDefaultValue
         case let value as NSString:
             self = .string(value as String)
+        case let value as Date:
+            self = .date(value)
         default:
             self = .other(value)
         }

--- a/Sources/UserDefaultsUI/Model/UserDefaultsActions.swift
+++ b/Sources/UserDefaultsUI/Model/UserDefaultsActions.swift
@@ -15,5 +15,6 @@ public protocol UserDefaultsActions {
     func valueForKey(_ key: String) -> Float
     func valueForKey(_ key: String) -> Double
     func valueForKey(_ key: String) -> String?
+    func valueForKey(_ key: String) -> Date?
     func valueForKey(_ key: String) -> Any?
 }

--- a/Sources/UserDefaultsUI/Model/UserDefaultsModel.swift
+++ b/Sources/UserDefaultsUI/Model/UserDefaultsModel.swift
@@ -21,7 +21,6 @@ public class UserDefaultsModel: ObservableObject {
         
         didChangeSubscription = NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification)
-            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refresh()

--- a/Sources/UserDefaultsUI/UserDefaultsBrowser.swift
+++ b/Sources/UserDefaultsUI/UserDefaultsBrowser.swift
@@ -40,6 +40,9 @@ public struct UserDefaultsBrowser: View {
                         Button("String") {
                             valueToAdd = .string("Placeholder")
                         }
+                        Button("Date") {
+                            valueToAdd = .date(Date.now)
+                        }
                     } label: {
                         Label("Add Key", systemImage: "plus")
                     }
@@ -77,6 +80,8 @@ public struct UserDefaultsBrowser: View {
                                 Text("\(String(value))")
                             case .string(let value):
                                 Text(value)
+                            case .date(let value):
+                                Text(value, style: .date)
                             case .other(_):
                                 Text("<\(entry.type)>")
                                     .foregroundStyle(.tertiary)
@@ -115,7 +120,8 @@ public struct UserDefaultsBrowser: View {
             "FloatKey": 3.14,
             "DoubleKey": 9.81,
             "StringKey": "String Value",
-            "DataKey": Data()
+            "DataKey": Data(),
+            "DateKey": Date.now
         ])
         let model = UserDefaultsModel(actions: actions, hidePrefixes: ["io.apparata."])
         UserDefaultsBrowser(model: model)


### PR DESCRIPTION
During my tests I encountered a problem with the refresh when updating the date, the date displayed in the UserDefaults entries list was not updated the first time. The only way I found to fix the problem was to delete the `dropFirst()` when receiving updates from the NotificationCenter publisher. I did not found any issue after this deletion.