### PR TITLE
Update list of iOS defaults UserDefaults keys and prefixes

### DIFF
--- a/Sources/UserDefaultsUI/Model/UserDefaultsModel.swift
+++ b/Sources/UserDefaultsUI/Model/UserDefaultsModel.swift
@@ -87,30 +87,31 @@ private extension String {
 private extension String {
     
     var isUserKey: Bool {
-        !hasSystemPrefix
+        !isSystemKey
     }
     
     var isSystemKey: Bool {
-        hasSystemPrefix
-    }
-    
-    var hasSystemPrefix: Bool {
-        
-        let prefixes = [
+        let systemKeysAndPrefixes = [
             "AddingEmojiKeybordHandled",
             "AK",
             "Apple",
+            "CarCapabilities",
             "com.apple.",
             "INNext",
             "internalSettings.",
             "METAL_",
+            "MPDebugEUVolumeLimit",
+            "MSVLoggingMasterSwitchEnabledKey",
+            "NNext",
             "NS",
             "PK",
+            "shouldShowRSVPDataDetectors",
+            "TVRC",
             "WebKit"
         ]
 
-        for prefix in prefixes {
-            if hasPrefix(prefix) {
+        for systemKeyOrPrefix in systemKeysAndPrefixes {
+            if hasPrefix(systemKeyOrPrefix) {
                 return true
             }
         }


### PR DESCRIPTION
Based on what the UserDefaults dictionnary returns on iOS 17.5 and iOS 18, both merged together.